### PR TITLE
Allow simultaneous gesture

### DIFF
--- a/Sources/CardStack/CardView.swift
+++ b/Sources/CardStack/CardView.swift
@@ -26,7 +26,7 @@ struct CardView<Direction, Content: View>: View {
       self.content(self.swipeDirection(geometry))
         .offset(self.translation)
         .rotationEffect(self.rotation(geometry))
-        .gesture(self.isOnTop ? self.dragGesture(geometry) : nil)
+        .simultaneousGesture(self.isOnTop ? self.dragGesture(geometry) : nil)
     }
     .transition(transition)
   }


### PR DESCRIPTION
The current gesture modifier would get blocked when the child view has the same kind of gesture attached.

https://developer.apple.com/documentation/swiftui/toggle/simultaneousgesture(_:including:)