### PR TITLE
Fixed using swipe threshold from configuration

### DIFF
--- a/Sources/CardStack/CardView.swift
+++ b/Sources/CardStack/CardView.swift
@@ -60,7 +60,7 @@ struct CardView<Direction, Content: View>: View {
 
   private func swipeDirection(_ geometry: GeometryProxy) -> Direction? {
     guard let direction = direction(degree) else { return nil }
-    let threshold = min(geometry.size.width, geometry.size.height) / 2
+    let threshold = min(geometry.size.width, geometry.size.height) * configuration.swipeThreshold
     let distance = hypot(translation.width, translation.height)
     return distance > threshold ? direction : nil
   }


### PR DESCRIPTION
`CardStackConfiguration` declares a `swipeThreshold` that's not used anywhere.

Indeed, the value is hardcoded in the `CardView.swipeDirection` method.