### PR TITLE
Set zIndex on card view to fix disappearance animation

### DIFF
--- a/Sources/CardStack/CardStack.swift
+++ b/Sources/CardStack/CardStack.swift
@@ -61,6 +61,7 @@ where Data.Index: Hashable {
           )
       }
     )
+    .zIndex(Double(data.count - data.distance(from: data.startIndex, to: index)))
   }
 
 }


### PR DESCRIPTION
This PR fixes issue #4
To fix the top card view from disappearing under the others, a zIndex is set to the cards according to their index.